### PR TITLE
chore: add PHPUnit unit tests and CI workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,39 @@
+---
+name: Unit tests
+
+on:
+    pull_request:
+    push:
+        branches:
+            - develop
+            - main
+    workflow_dispatch:
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    php-unit:
+        name: PHP unit tests
+        runs-on: ubuntu-latest
+        timeout-minutes: 15
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v5
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '8.2'
+                  extensions: mbstring
+                  coverage: none
+
+            - name: Install Composer dependencies
+              uses: ramsey/composer-install@v4
+              with:
+                  composer-options: '--prefer-dist --no-interaction'
+
+            - name: Run PHPUnit
+              run: composer run test:php

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ coverage
 # Dependency directories
 node_modules/
 vendor/
-build/
+/build/
 
 # Optional npm cache directory
 .npm

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ yarn-error.log*
 
 # Coverage directory used by tools like istanbul
 coverage
+.phpunit.cache
+.phpunit.result.cache
 
 # Dependency directories
 node_modules/

--- a/composer.json
+++ b/composer.json
@@ -2,10 +2,18 @@
 	"name": "evrpress/freemius-button",
 	"require": {},
 	"require-dev": {
+		"brain/monkey": "^2.6",
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
+		"phpunit/phpunit": "^9.6",
 		"squizlabs/php_codesniffer": "^3.7",
-		"wp-coding-standards/wpcs": "^3.0"
+		"wp-coding-standards/wpcs": "^3.0",
+		"yoast/phpunit-polyfills": "^2.0"
+	},
+	"autoload-dev": {
+		"psr-4": {
+			"Freemius\\Tests\\": "tests/php/"
+		}
 	},
 	"config": {
 		"allow-plugins": {
@@ -14,6 +22,7 @@
 	},
 	"scripts": {
 		"lint:php": "phpcs",
-		"lint:php:fix": "phpcbf"
+		"lint:php:fix": "phpcbf",
+		"test:php": "phpunit --configuration phpunit.xml.dist"
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,127 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "742a3d922da3bbd590b909e72c94fbba",
+    "content-hash": "39cbd26758361bafd6e3c87d0d30b20d",
     "packages": [],
     "packages-dev": [
+        {
+            "name": "antecedent/patchwork",
+            "version": "2.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/antecedent/patchwork.git",
+                "reference": "8b6b235f405af175259c8f56aea5fc23ab9f03ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/8b6b235f405af175259c8f56aea5fc23ab9f03ce",
+                "reference": "8b6b235f405af175259c8f56aea5fc23ab9f03ce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=4"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignas Rudaitis",
+                    "email": "ignas.rudaitis@gmail.com"
+                }
+            ],
+            "description": "Method redefinition (monkey-patching) functionality for PHP.",
+            "homepage": "https://antecedent.github.io/patchwork/",
+            "keywords": [
+                "aop",
+                "aspect",
+                "interception",
+                "monkeypatching",
+                "redefinition",
+                "runkit",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/antecedent/patchwork/issues",
+                "source": "https://github.com/antecedent/patchwork/tree/2.2.3"
+            },
+            "time": "2025-09-17T09:00:56+00:00"
+        },
+        {
+            "name": "brain/monkey",
+            "version": "2.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Brain-WP/BrainMonkey.git",
+                "reference": "ea3aeb3d559ba3c0930b3f4d210b665a4c044d83"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Brain-WP/BrainMonkey/zipball/ea3aeb3d559ba3c0930b3f4d210b665a4c044d83",
+                "reference": "ea3aeb3d559ba3c0930b3f4d210b665a4c044d83",
+                "shasum": ""
+            },
+            "require": {
+                "antecedent/patchwork": "^2.1.17",
+                "mockery/mockery": "~1.3.6 || ~1.4.4 || ~1.5.1 || ^1.6.10",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
+                "phpcompatibility/php-compatibility": "^9.3.0",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.49 || ^9.6.30"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev",
+                    "dev-version/1": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "inc/api.php"
+                ],
+                "psr-4": {
+                    "Brain\\Monkey\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Giuseppe Mazzapica",
+                    "email": "giuseppe.mazzapica@gmail.com",
+                    "homepage": "https://gmazzap.me",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Mocking utility for PHP functions and WordPress plugin API",
+            "keywords": [
+                "Monkey Patching",
+                "interception",
+                "mock",
+                "mock functions",
+                "mockery",
+                "patchwork",
+                "redefinition",
+                "runkit",
+                "test",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Brain-WP/BrainMonkey/issues",
+                "source": "https://github.com/Brain-WP/BrainMonkey"
+            },
+            "time": "2026-02-05T09:22:14+00:00"
+        },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
             "version": "v1.2.1",
@@ -102,6 +220,446 @@
                 }
             ],
             "time": "2026-05-06T08:26:05+00:00"
+        },
+        {
+            "name": "doctrine/instantiator",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^11",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-12-30T00:23:10+00:00"
+        },
+        {
+            "name": "hamcrest/hamcrest-php",
+            "version": "v2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hamcrest/hamcrest-php.git",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "replace": {
+                "cordoval/hamcrest-php": "*",
+                "davedevelopment/hamcrest-php": "*",
+                "kodova/hamcrest-php": "*"
+            },
+            "require-dev": {
+                "phpunit/php-file-iterator": "^1.4 || ^2.0 || ^3.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "hamcrest"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "This is the PHP port of Hamcrest Matchers",
+            "keywords": [
+                "test"
+            ],
+            "support": {
+                "issues": "https://github.com/hamcrest/hamcrest-php/issues",
+                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.1.1"
+            },
+            "time": "2025-04-30T06:54:44+00:00"
+        },
+        {
+            "name": "mockery/mockery",
+            "version": "1.6.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mockery/mockery.git",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "shasum": ""
+            },
+            "require": {
+                "hamcrest/hamcrest-php": "^2.0.1",
+                "lib-pcre": ">=7.0",
+                "php": ">=7.3"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5 || ^9.6.17",
+                "symplify/easy-coding-standard": "^12.1.14"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "library/helpers.php",
+                    "library/Mockery.php"
+                ],
+                "psr-4": {
+                    "Mockery\\": "library/Mockery"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "https://github.com/padraic",
+                    "role": "Author"
+                },
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "https://davedevelopment.co.uk",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Nathanael Esayeas",
+                    "email": "nathanael.esayeas@protonmail.com",
+                    "homepage": "https://github.com/ghostwriter",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "Mockery is a simple yet flexible PHP mock object framework",
+            "homepage": "https://github.com/mockery/mockery",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "library",
+                "mock",
+                "mock objects",
+                "mockery",
+                "stub",
+                "test",
+                "test double",
+                "testing"
+            ],
+            "support": {
+                "docs": "https://docs.mockery.io/",
+                "issues": "https://github.com/mockery/mockery/issues",
+                "rss": "https://github.com/mockery/mockery/releases.atom",
+                "security": "https://github.com/mockery/mockery/security/advisories",
+                "source": "https://github.com/mockery/mockery"
+            },
+            "time": "2024-05-16T03:13:13+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+            },
+            "time": "2025-12-06T11:56:16+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -492,6 +1050,1447 @@
             "time": "2025-12-08T14:27:58+00:00"
         },
         {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.32",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:23:01+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "3.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-02T12:48:52+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:16:10+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "9.6.34",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b36f02317466907a230d3aa1d34467041271ef4a",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.5.0 || ^2",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
+                "sebastian/comparator": "^4.0.10",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.8",
+                "sebastian/global-state": "^5.0.8",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
+                "sebastian/version": "^3.0.2"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.34"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-27T05:45:00+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:27:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:30:19+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "4.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:22:56+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:19:30+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:30:58+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "5.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:03:51+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "4.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:03:27+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "5.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T07:10:35+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:20:34+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:12:34+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:14:26+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T06:57:39+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-14T16:00:52+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:13:03+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
             "name": "squizlabs/php_codesniffer",
             "version": "3.13.5",
             "source": {
@@ -571,6 +2570,56 @@
             "time": "2025-11-04T16:30:35+00:00"
         },
         {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
+        },
+        {
             "name": "wp-coding-standards/wpcs",
             "version": "3.3.0",
             "source": {
@@ -635,6 +2684,69 @@
                 }
             ],
             "time": "2025-11-25T12:08:04+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "2.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "1a6aecc9ebe4a9cea4e1047d0e6c496e52314c27"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/1a6aecc9ebe4a9cea4e1047d0e6c496e52314c27",
+                "reference": "1a6aecc9ebe4a9cea4e1047d0e6c496e52314c27",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "phpunit/phpunit": "^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "yoast/yoastcs": "^3.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+                "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
+                "source": "https://github.com/Yoast/PHPUnit-Polyfills"
+            },
+            "time": "2025-08-10T05:13:49+00:00"
         }
     ],
     "aliases": [],

--- a/includes/class-freemius-api.php
+++ b/includes/class-freemius-api.php
@@ -468,21 +468,19 @@ class Api {
 	 * @return array|null Dummy response body or null.
 	 */
 	private function get_dummy_response( string $endpoint ) {
-
-		include_once __DIR__ . '/dummy-response.php';
-
-		$body = null;
+		$dummy = $this->load_dummy_response_data();
+		$body  = null;
 
 		if ( substr( $endpoint, -strlen( '/currencies.json' ) ) === '/currencies.json' ) {
-			$body = $currencies;
+			$body = $dummy['currencies'];
 		}
 
 		if ( substr( $endpoint, -strlen( '/pricing.json' ) ) === '/pricing.json' ) {
-			$body = $pricing;
+			$body = $dummy['pricing'];
 		}
 
 		if ( substr( $endpoint, -strlen( '/products/19794.json' ) ) === '/products/19794.json' ) {
-			$body = $product;
+			$body = $dummy['product'];
 		}
 
 		return array(
@@ -495,5 +493,30 @@ class Api {
 			'cookies'            => array(),
 			'http_response_code' => 200,
 		);
+	}
+
+	/**
+	 * Load dummy response payloads once per request.
+	 *
+	 * @since 0.4.2
+	 *
+	 * @return array<string, string|null>
+	 */
+	private function load_dummy_response_data(): array {
+		static $data = null;
+
+		if ( null !== $data ) {
+			return $data;
+		}
+
+		include __DIR__ . '/dummy-response.php';
+
+		$data = array(
+			'pricing'    => $pricing,
+			'currencies' => $currencies,
+			'product'    => $product,
+		);
+
+		return $data;
 	}
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
 		"lint:php:fix": "composer run lint:php:fix",
 		"packages-update": "wp-scripts packages-update",
 		"plugin-zip": "wp-scripts plugin-zip",
-		"start": "wp-scripts start  --experimental-modules"
+		"start": "wp-scripts start  --experimental-modules",
+		"test:php": "composer run test:php"
 	},
 	"files": [
 		"build",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -7,6 +7,7 @@
 	<exclude-pattern>/vendor/*</exclude-pattern>
 	<exclude-pattern>/node_modules/*</exclude-pattern>
 	<exclude-pattern>/build/*</exclude-pattern>
+	<exclude-pattern>/tests/*</exclude-pattern>
 
 	<!-- How to scan -->
 	<arg value="sp"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<phpunit
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+	bootstrap="tests/php/bootstrap.php"
+	colors="true"
+	cacheResult="true"
+>
+	<testsuites>
+		<testsuite name="Freemius PHP">
+			<directory suffix="Test.php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/tests/fixtures/build/button/view.asset.php
+++ b/tests/fixtures/build/button/view.asset.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Minimal webpack asset manifest for Button view tests.
+ *
+ * @package Freemius
+ */
+
+return array(
+	'dependencies' => array(),
+	'version'      => 'test',
+);

--- a/tests/fixtures/build/scope/index.asset.php
+++ b/tests/fixtures/build/scope/index.asset.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Minimal webpack asset manifest for Scope editor tests.
+ *
+ * @package Freemius
+ */
+
+return array(
+	'dependencies' => array(),
+	'version'      => 'test',
+);

--- a/tests/php/ApiTest.php
+++ b/tests/php/ApiTest.php
@@ -1,0 +1,290 @@
+<?php
+/**
+ * Tests for Freemius Api.
+ *
+ * @package Freemius
+ */
+
+declare(strict_types=1);
+
+namespace Freemius\Tests;
+
+use Brain\Monkey\Functions;
+use Freemius\Api;
+use WP_REST_Request;
+
+class ApiTest extends Freemius_TestCase {
+
+	public function test_check_permissions_delegates_to_current_user_can(): void {
+		Functions\expect( 'current_user_can' )
+			->once()
+			->with( 'manage_options' )
+			->andReturn( true );
+
+		$this->assertTrue( Api::get_instance()->check_permissions() );
+	}
+
+	public function test_check_permissions_returns_false_when_user_cannot_manage_options(): void {
+		Functions\expect( 'current_user_can' )
+			->once()
+			->with( 'manage_options' )
+			->andReturn( false );
+
+		$this->assertFalse( Api::get_instance()->check_permissions() );
+	}
+
+	public function test_get_request_returns_error_when_not_configured(): void {
+		$this->options['freemius_settings'] = array();
+
+		$result = Api::get_instance()->get_request( 'products/19794/pricing.json' );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'freemius_api_not_configured', $result->get_error_code() );
+	}
+
+	public function test_get_request_returns_dummy_pricing_with_cache_miss_header(): void {
+		$this->options['freemius_settings'] = array(
+			'token' => '1234567890',
+		);
+
+		$result = Api::get_instance()->get_request( 'products/19794/pricing.json' );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $result );
+		$this->assertSame( 200, $result->get_status() );
+		$this->assertSame( 'MISS', $result->get_header( 'X-Freemius-Cache' ) );
+
+		$data = $result->get_data();
+		$this->assertIsArray( $data );
+		$this->assertArrayHasKey( 'plans', $data );
+	}
+
+	public function test_get_request_returns_cache_hit_on_second_call(): void {
+		$this->options['freemius_settings'] = array(
+			'token' => '1234567890',
+		);
+
+		$api = Api::get_instance();
+		$api->get_request( 'products/19794/pricing.json' );
+
+		$result = $api->get_request( 'products/19794/pricing.json' );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $result );
+		$this->assertSame( 'HIT', $result->get_header( 'X-Freemius-Cache' ) );
+	}
+
+	public function test_set_cache_expiry_controls_transient_ttl_argument(): void {
+		$this->options['freemius_settings'] = array(
+			'token' => '1234567890',
+		);
+
+		$api = Api::get_instance();
+		$api->set_cache_expiry( 7200 );
+		$api->get_request( 'products/19794/pricing.json' );
+
+		$this->assertSame( 7200, $this->get_last_transient_expiry() );
+	}
+
+	public function test_get_request_uses_product_specific_token(): void {
+		$this->options['freemius_settings'] = array(
+			'token' => 'global-token',
+		);
+		$this->options['freemius_products'] = array(
+			array(
+				'product_id' => 19794,
+				'token'      => '1234567890',
+			),
+		);
+
+		$result = Api::get_instance()->get_request( 'products/19794/pricing.json' );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $result );
+		$this->assertArrayHasKey( 'plans', $result->get_data() );
+	}
+
+	public function test_proxy_get_request_strips_endpoint_and_locale_from_query_params(): void {
+		$this->options['freemius_settings'] = array(
+			'token' => '1234567890',
+		);
+
+		$request = new WP_REST_Request( 'GET', '/freemius/v1/proxy/products/19794/pricing.json' );
+		$request->set_param( 'endpoint', 'products/19794/pricing.json' );
+		$request->set_query_params(
+			array(
+				'endpoint' => 'products/19794/pricing.json',
+				'_locale'  => 'user',
+				'currency' => 'usd',
+			)
+		);
+
+		$result = Api::get_instance()->proxy_get_request( $request );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $result );
+		$this->assertSame( 200, $result->get_status() );
+	}
+
+	public function test_proxy_request_forwards_post_body(): void {
+		global $wpdb;
+
+		$wpdb          = new class() {
+			public $options = 'wp_options';
+
+			/**
+			 * @param string $query SQL query.
+			 * @param mixed  $like  LIKE value.
+			 * @return string
+			 */
+			public function prepare( $query, $like ) {
+				unset( $like );
+				return $query;
+			}
+
+			/**
+			 * @param string $query SQL query.
+			 * @return array<int, string>
+			 */
+			public function get_col( $query ) {
+				unset( $query );
+				return array();
+			}
+		};
+
+		$this->options['freemius_settings'] = array(
+			'token' => 'real-token',
+		);
+
+		Functions\expect( 'wp_remote_request' )
+			->once()
+			->with(
+				\Mockery::type( 'string' ),
+				\Mockery::type( 'array' )
+			)
+			->andReturn(
+				array(
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'body'     => wp_json_encode( array( 'success' => true ) ),
+				)
+			);
+
+		$request = new WP_REST_Request( 'POST', '/freemius/v1/proxy/products/19794.json' );
+		$request->set_param( 'endpoint', 'products/19794.json' );
+		$request->set_json_params( array( 'title' => 'Updated' ) );
+
+		$result = Api::get_instance()->proxy_request( $request );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $result );
+		$this->assertSame( array( 'success' => true ), $result->get_data() );
+	}
+
+	public function test_get_request_handles_wp_remote_request_failure(): void {
+		$this->options['freemius_settings'] = array(
+			'token' => 'real-token',
+		);
+
+		Functions\expect( 'wp_remote_request' )
+			->once()
+			->andReturn( new \WP_Error( 'http_request_failed', 'Connection timed out' ) );
+
+		$result = Api::get_instance()->get_request( 'products/19794/pricing.json' );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'freemius_api_request_failed', $result->get_error_code() );
+	}
+
+	public function test_get_request_handles_api_error_response(): void {
+		$this->options['freemius_settings'] = array(
+			'token' => 'real-token',
+		);
+
+		Functions\expect( 'wp_remote_request' )
+			->once()
+			->andReturn(
+				array(
+					'response' => array(
+						'code'    => 403,
+						'message' => 'Forbidden',
+					),
+					'body'     => wp_json_encode(
+						array(
+							'error' => array(
+								'message' => 'Invalid token',
+							),
+						)
+					),
+				)
+			);
+
+		$result = Api::get_instance()->get_request( 'products/19794/pricing.json' );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'freemius_api_error', $result->get_error_code() );
+		$this->assertSame( 'Invalid token', $result->get_error_message() );
+	}
+
+	public function test_get_request_handles_invalid_json_response(): void {
+		$this->options['freemius_settings'] = array(
+			'token' => 'real-token',
+		);
+
+		Functions\expect( 'wp_remote_request' )
+			->once()
+			->andReturn(
+				array(
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'body'     => 'not-json',
+				)
+			);
+
+		$result = Api::get_instance()->get_request( 'products/19794/pricing.json' );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'freemius_api_invalid_response', $result->get_error_code() );
+	}
+
+	public function test_clear_cache_returns_success_message(): void {
+		global $wpdb;
+
+		$wpdb          = new class() {
+			public $options = 'wp_options';
+
+			/**
+			 * @param string $query SQL query.
+			 * @param mixed  $like  LIKE value.
+			 * @return string
+			 */
+			public function prepare( $query, $like ) {
+				unset( $like );
+				return $query;
+			}
+
+			/**
+			 * @param string $query SQL query.
+			 * @return array<int, string>
+			 */
+			public function get_col( $query ) {
+				unset( $query );
+				return array(
+					'_transient_freemius_api_abc123',
+					'_transient_freemius_api_def456',
+				);
+			}
+		};
+
+		$this->transients['freemius_api_abc123'] = array( 'data' => array(), 'status' => 200 );
+		$this->transients['freemius_api_def456'] = array( 'data' => array(), 'status' => 200 );
+
+		$request = new WP_REST_Request( 'POST', '/freemius/v1/cache/clear' );
+		$result  = Api::get_instance()->clear_cache( $request );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $result );
+		$this->assertSame( 200, $result->get_status() );
+		$this->assertSame( 'Cache cleared successfully.', $result->get_data()['message'] );
+		$this->assertArrayNotHasKey( 'freemius_api_abc123', $this->transients );
+		$this->assertArrayNotHasKey( 'freemius_api_def456', $this->transients );
+	}
+}

--- a/tests/php/BlocksTest.php
+++ b/tests/php/BlocksTest.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Tests for Freemius Blocks.
+ *
+ * @package Freemius
+ */
+
+declare(strict_types=1);
+
+namespace Freemius\Tests;
+
+use Brain\Monkey\Functions;
+use Freemius\Blocks;
+
+class BlocksTest extends Freemius_TestCase {
+
+	public function test_register_blocks_registers_modifier_block(): void {
+		$registered_path = null;
+
+		Functions\when( 'register_block_type' )->alias(
+			static function ( $path ) use ( &$registered_path ) {
+				$registered_path = $path;
+			}
+		);
+
+		Blocks::get_instance()->register_blocks();
+
+		$this->assertSame( FREEMIUS_PLUGIN_DIR . '/build/blocks/modifier', $registered_path );
+	}
+}

--- a/tests/php/ButtonTest.php
+++ b/tests/php/ButtonTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Tests for Freemius Button.
+ *
+ * @package Freemius
+ */
+
+declare(strict_types=1);
+
+namespace Freemius\Tests;
+
+use Brain\Monkey\Functions;
+use Freemius\Button;
+
+class ButtonTest extends Freemius_TestCase {
+
+	public function test_render_button_returns_unchanged_without_attrs(): void {
+		$button  = Button::get_instance();
+		$content = '<div class="wp-block-button">Buy</div>';
+
+		$result = $button->render_button( $content, array(), array() );
+
+		$this->assertSame( $content, $result );
+	}
+
+	public function test_render_button_returns_unchanged_when_disabled(): void {
+		$button  = Button::get_instance();
+		$content = '<div class="wp-block-button">Buy</div>';
+		$block   = array(
+			'attrs' => array(
+				'freemius_enabled' => false,
+			),
+		);
+
+		$result = $button->render_button( $content, $block, array() );
+
+		$this->assertSame( $content, $result );
+	}
+
+	public function test_render_button_enqueues_scripts_when_enabled(): void {
+		$enqueue_calls = 0;
+
+		Functions\when( 'wp_enqueue_script' )->alias(
+			static function () use ( &$enqueue_calls ) {
+				++$enqueue_calls;
+			}
+		);
+
+		$button  = Button::get_instance();
+		$content = '<div class="wp-block-button">Buy</div>';
+		$block   = array(
+			'attrs' => array(
+				'freemius_enabled' => true,
+			),
+		);
+
+		$result = $button->render_button( $content, $block, array() );
+
+		$this->assertSame( $content, $result );
+		$this->assertSame( 2, $enqueue_calls );
+	}
+}

--- a/tests/php/Freemius_TestCase.php
+++ b/tests/php/Freemius_TestCase.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * Base TestCase with Brain Monkey lifecycle for WordPress function stubs.
+ *
+ * @package Freemius
+ */
+
+declare(strict_types=1);
+
+namespace Freemius\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Freemius\Api;
+use Freemius\Blocks;
+use Freemius\Button;
+use Freemius\Scope;
+use Freemius\Settings;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+abstract class Freemius_TestCase extends TestCase {
+
+	/**
+	 * Shared mutable state for option/transient stubs across tests.
+	 *
+	 * @var array{options: array<string, mixed>, transients: array<string, mixed>, last_transient_expiry: int|null}
+	 */
+	private $storage = array(
+		'options'               => array(),
+		'transients'            => array(),
+		'last_transient_expiry' => null,
+	);
+
+	/**
+	 * @var array<string, mixed>
+	 */
+	protected $options = array();
+
+	/**
+	 * @var array<string, mixed>
+	 */
+	protected $transients = array();
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		$this->storage['options']               = array();
+		$this->storage['transients']            = array();
+		$this->storage['last_transient_expiry'] = null;
+		$this->options                          = &$this->storage['options'];
+		$this->transients                       = &$this->storage['transients'];
+
+		Functions\when( '__' )->returnArg( 1 );
+		Functions\when( 'apply_filters' )->alias(
+			static function ( $hook, $value, ...$args ) {
+				unset( $hook, $args );
+				return $value;
+			}
+		);
+		Functions\when( 'esc_attr' )->alias(
+			static function ( $text ) {
+				return htmlspecialchars( (string) $text, ENT_QUOTES, 'UTF-8' );
+			}
+		);
+		Functions\when( 'wp_json_encode' )->alias(
+			static function ( $data ) {
+				return json_encode( $data );
+			}
+		);
+		Functions\when( 'is_wp_error' )->alias(
+			static function ( $thing ) {
+				return $thing instanceof \WP_Error;
+			}
+		);
+		Functions\when( 'sanitize_text_field' )->alias(
+			static function ( $text ) {
+				return trim( strip_tags( (string) $text ) );
+			}
+		);
+		Functions\when( 'wp_parse_args' )->alias(
+			static function ( $args, $defaults = array() ) {
+				if ( ! is_array( $args ) ) {
+					return $defaults;
+				}
+
+				return array_merge( $defaults, $args );
+			}
+		);
+
+		$this->stub_options_and_transients();
+		$this->reset_singletons();
+	}
+
+	protected function tearDown(): void {
+		global $wpdb;
+
+		$this->reset_singletons();
+		$wpdb = null;
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Stub get_option, update_option, get_transient, set_transient, delete_transient.
+	 */
+	protected function stub_options_and_transients(): void {
+		$storage = &$this->storage;
+
+		Functions\when( 'get_option' )->alias(
+			static function ( $option, $default = false ) use ( &$storage ) {
+				return $storage['options'][ $option ] ?? $default;
+			}
+		);
+		Functions\when( 'update_option' )->alias(
+			static function ( $option, $value ) use ( &$storage ) {
+				$storage['options'][ $option ] = $value;
+				return true;
+			}
+		);
+		Functions\when( 'get_transient' )->alias(
+			static function ( $key ) use ( &$storage ) {
+				return $storage['transients'][ $key ] ?? false;
+			}
+		);
+		Functions\when( 'set_transient' )->alias(
+			static function ( $key, $value, $expiry = 0 ) use ( &$storage ) {
+				$storage['last_transient_expiry'] = (int) $expiry;
+				$storage['transients'][ $key ]    = $value;
+				return true;
+			}
+		);
+		Functions\when( 'delete_transient' )->alias(
+			static function ( $key ) use ( &$storage ) {
+				unset( $storage['transients'][ $key ] );
+				return true;
+			}
+		);
+	}
+
+	/**
+	 * Reset singleton instances and Scope matrix state between tests.
+	 */
+	protected function reset_singletons(): void {
+		$classes = array(
+			Api::class,
+			Settings::class,
+			Scope::class,
+			Button::class,
+			Blocks::class,
+		);
+
+		foreach ( $classes as $class ) {
+			$reflection = new ReflectionClass( $class );
+			$property   = $reflection->getProperty( 'instance' );
+			$property->setAccessible( true );
+			$property->setValue( null, null );
+		}
+
+		$scope = Scope::get_instance();
+		$ref   = new ReflectionClass( $scope );
+		if ( $ref->hasProperty( 'matrix_added' ) ) {
+			$matrix = $ref->getProperty( 'matrix_added' );
+			$matrix->setAccessible( true );
+			$matrix->setValue( $scope, array() );
+		}
+
+		$api     = Api::get_instance();
+		$api_ref = new ReflectionClass( $api );
+		if ( $api_ref->hasProperty( 'api_settings' ) ) {
+			$settings_prop = $api_ref->getProperty( 'api_settings' );
+			$settings_prop->setAccessible( true );
+			$settings_prop->setValue( $api, null );
+		}
+	}
+
+	/**
+	 * @return int|null
+	 */
+	protected function get_last_transient_expiry(): ?int {
+		return $this->storage['last_transient_expiry'];
+	}
+}

--- a/tests/php/ScopeTest.php
+++ b/tests/php/ScopeTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Tests for Freemius Scope.
+ *
+ * @package Freemius
+ */
+
+declare(strict_types=1);
+
+namespace Freemius\Tests;
+
+use Freemius\Scope;
+
+class ScopeTest extends Freemius_TestCase {
+
+	public function test_render_scope_returns_unchanged_without_attrs(): void {
+		$scope   = Scope::get_instance();
+		$content = '<div class="wp-block-group">Original</div>';
+
+		$result = $scope->render_scope( $content, array(), array() );
+
+		$this->assertSame( $content, $result );
+	}
+
+	public function test_render_scope_returns_unchanged_when_disabled(): void {
+		$scope   = Scope::get_instance();
+		$content = '<div class="wp-block-group">Original</div>';
+		$block   = array(
+			'attrs' => array(
+				'freemius_enabled' => false,
+				'freemius'         => array(
+					'product_id' => 19794,
+				),
+			),
+		);
+
+		$result = $scope->render_scope( $content, $block, array() );
+
+		$this->assertSame( $content, $result );
+	}
+
+	public function test_render_scope_injects_scope_json_scripts(): void {
+		$this->options['freemius_defaults'] = array(
+			'currency' => 'usd',
+		);
+
+		$scope   = Scope::get_instance();
+		$content = '<div class="wp-block-group">Original</div>';
+		$block   = array(
+			'attrs' => array(
+				'freemius_enabled' => true,
+				'freemius'         => array(
+					'plan_id' => '32842',
+				),
+			),
+		);
+
+		$result = $scope->render_scope( $content, $block, array() );
+
+		$this->assertStringContainsString( 'freemius-global-scope-data', $result );
+		$this->assertStringContainsString( 'freemius-scope-data', $result );
+		$this->assertStringContainsString( '"plan_id":"32842"', $result );
+		$this->assertStringContainsString( $content, $result );
+	}
+
+	public function test_render_scope_includes_matrix_for_product(): void {
+		$this->options['freemius_settings'] = array(
+			'token' => '1234567890',
+		);
+
+		$scope   = Scope::get_instance();
+		$content = '<div class="wp-block-group">Original</div>';
+		$block   = array(
+			'attrs' => array(
+				'freemius_enabled' => true,
+				'freemius'         => array(
+					'product_id' => 19794,
+				),
+			),
+		);
+
+		$result = $scope->render_scope( $content, $block, array() );
+
+		$this->assertStringContainsString( 'freemius-matrix-data', $result );
+		$this->assertStringContainsString( 'data-freemius-product-id="19794"', $result );
+		$this->assertStringContainsString( '"32841"', $result );
+		$this->assertStringContainsString( '"32842"', $result );
+	}
+
+	public function test_render_scope_deduplicates_matrix_per_product(): void {
+		$this->options['freemius_settings'] = array(
+			'token' => '1234567890',
+		);
+
+		$scope   = Scope::get_instance();
+		$content = '<div>Block</div>';
+		$block   = array(
+			'attrs' => array(
+				'freemius_enabled' => true,
+				'freemius'         => array(
+					'product_id' => 19794,
+				),
+			),
+		);
+
+		$first  = $scope->render_scope( $content, $block, array() );
+		$second = $scope->render_scope( $content, $block, array() );
+
+		$this->assertSame( 1, substr_count( $first, 'freemius-matrix-data' ) );
+		$this->assertSame( 0, substr_count( $second, 'freemius-matrix-data' ) );
+	}
+}

--- a/tests/php/SettingsTest.php
+++ b/tests/php/SettingsTest.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Tests for Freemius Settings.
+ *
+ * @package Freemius
+ */
+
+declare(strict_types=1);
+
+namespace Freemius\Tests;
+
+use Brain\Monkey\Functions;
+use Freemius\Settings;
+
+class SettingsTest extends Freemius_TestCase {
+
+	public function test_sanitize_settings_returns_empty_array_for_non_array(): void {
+		$settings = Settings::get_instance();
+
+		$this->assertSame( array(), $settings->sanitize_settings( 'invalid' ) );
+		$this->assertSame( array(), $settings->sanitize_settings( null ) );
+	}
+
+	public function test_sanitize_settings_sanitizes_strings_and_nested_arrays(): void {
+		$settings = Settings::get_instance();
+
+		$result = $settings->sanitize_settings(
+			array(
+				'token'  => '<script>alert(1)</script>secret',
+				'nested' => array(
+					'label' => '<b>Hello</b>',
+				),
+			)
+		);
+
+		$this->assertSame( 'alert(1)secret', $result['token'] );
+		$this->assertSame( 'Hello', $result['nested']['label'] );
+	}
+
+	public function test_sanitize_settings_preserves_bools_and_numbers(): void {
+		$settings = Settings::get_instance();
+
+		$result = $settings->sanitize_settings(
+			array(
+				'enabled' => true,
+				'count'   => 3,
+				'price'   => 9.99,
+			)
+		);
+
+		$this->assertTrue( $result['enabled'] );
+		$this->assertSame( 3, $result['count'] );
+		$this->assertSame( 9.99, $result['price'] );
+	}
+
+	public function test_sanitize_schema_removes_empty_strings(): void {
+		$settings = Settings::get_instance();
+
+		$result = $settings->sanitize_schema(
+			array(
+				'product_id' => '',
+				'plan_id'    => '32842',
+				'currency'   => '',
+			)
+		);
+
+		$this->assertArrayNotHasKey( 'product_id', $result );
+		$this->assertArrayNotHasKey( 'currency', $result );
+		$this->assertSame( '32842', $result['plan_id'] );
+	}
+
+	public function test_get_schema_returns_environment_key(): void {
+		$settings = Settings::get_instance();
+		$schema   = $settings->get_schema();
+
+		$this->assertIsArray( $schema );
+		$this->assertArrayHasKey( 'environment', $schema );
+	}
+
+	public function test_get_button_schema_returns_product_id_key(): void {
+		$settings = Settings::get_instance();
+		$schema   = $settings->get_button_schema();
+
+		$this->assertIsArray( $schema );
+		$this->assertArrayHasKey( 'product_id', $schema );
+	}
+
+	public function test_get_products_schema_returns_expected_keys(): void {
+		$settings = Settings::get_instance();
+		$schema   = $settings->get_products_schema();
+
+		$this->assertIsArray( $schema );
+		$this->assertArrayHasKey( 'product_id', $schema );
+		$this->assertArrayHasKey( 'token', $schema );
+	}
+
+	public function test_add_plugin_action_links_prepends_settings_link(): void {
+		Functions\when( 'admin_url' )->justReturn( 'http://example.org/wp-admin/options-general.php?page=freemius-settings' );
+
+		$settings = Settings::get_instance();
+		$links    = $settings->add_plugin_action_links( array( '<a href="#">Deactivate</a>' ) );
+
+		$this->assertCount( 2, $links );
+		$this->assertStringContainsString( 'freemius-settings', $links[0] );
+		$this->assertStringContainsString( 'Settings', $links[0] );
+	}
+}

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * PHPUnit bootstrap — defines minimal WordPress constants and loads plugin classes.
+ *
+ * @package Freemius
+ */
+
+declare(strict_types=1);
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals -- WordPress API stubs for PHPUnit.
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', sys_get_temp_dir() . '/freemius-phpunit-abspath/' );
+}
+
+$freemius_plugin_root = dirname( __DIR__, 2 );
+
+if ( ! defined( 'FREEMIUS_PLUGIN_DIR' ) ) {
+	define( 'FREEMIUS_PLUGIN_DIR', $freemius_plugin_root . '/' );
+}
+
+if ( ! defined( 'FREEMIUS_PLUGIN_URL' ) ) {
+	define( 'FREEMIUS_PLUGIN_URL', 'http://example.org/wp-content/plugins/freemius/' );
+}
+
+if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
+	define( 'HOUR_IN_SECONDS', 3600 );
+}
+
+if ( ! defined( 'WP_DEBUG' ) ) {
+	define( 'WP_DEBUG', false );
+}
+
+require_once $freemius_plugin_root . '/vendor/autoload.php';
+require_once __DIR__ . '/stubs/wp-classes.php';
+
+/**
+ * Copy committed build fixtures into build/ when webpack output is absent.
+ *
+ * @param string $plugin_root Plugin root path.
+ */
+function freemius_phpunit_prepare_build_fixtures( string $plugin_root ): void {
+	$fixtures_root = $plugin_root . '/tests/fixtures/build';
+	$build_root    = $plugin_root . '/build';
+
+	if ( ! is_dir( $fixtures_root ) ) {
+		return;
+	}
+
+	$iterator = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator( $fixtures_root, RecursiveDirectoryIterator::SKIP_DOTS ),
+		RecursiveIteratorIterator::SELF_FIRST
+	);
+
+	foreach ( $iterator as $item ) {
+		if ( ! $item->isFile() ) {
+			continue;
+		}
+
+		$relative = substr( $item->getPathname(), strlen( $fixtures_root ) + 1 );
+		$target   = $build_root . '/' . $relative;
+
+		if ( file_exists( $target ) ) {
+			continue;
+		}
+
+		$target_dir = dirname( $target );
+		if ( ! is_dir( $target_dir ) ) {
+			mkdir( $target_dir, 0777, true );
+		}
+
+		copy( $item->getPathname(), $target );
+	}
+}
+
+freemius_phpunit_prepare_build_fixtures( $freemius_plugin_root );
+
+spl_autoload_register(
+	static function ( string $class_name ) {
+		$prefix = 'Freemius\\';
+
+		$len = strlen( $prefix );
+		if ( strncmp( $prefix, $class_name, $len ) !== 0 ) {
+			return;
+		}
+
+		$relative_class = substr( $class_name, $len );
+		$base_dir       = FREEMIUS_PLUGIN_DIR . 'includes/';
+		$file           = $base_dir . 'class-freemius-' . strtolower( str_replace( '_', '-', $relative_class ) ) . '.php';
+
+		if ( file_exists( $file ) ) {
+			require $file;
+		}
+	}
+);

--- a/tests/php/stubs/wp-classes.php
+++ b/tests/php/stubs/wp-classes.php
@@ -1,0 +1,289 @@
+<?php
+/**
+ * Minimal WordPress REST and error stubs for PHPUnit.
+ *
+ * @package Freemius
+ */
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals -- WordPress API stubs for PHPUnit.
+
+if ( ! class_exists( 'WP_REST_Request', false ) ) {
+	/**
+	 * Minimal REST request stub for PHPUnit.
+	 */
+	class WP_REST_Request {
+		/**
+		 * @var array<string, mixed>
+		 */
+		private $params = array();
+
+		/**
+		 * @var array<string, mixed>
+		 */
+		private $query_params = array();
+
+		/**
+		 * @var string
+		 */
+		private $method = 'GET';
+
+		/**
+		 * @var array<string, mixed>|null
+		 */
+		private $json_params = null;
+
+		/**
+		 * @param string $method HTTP method.
+		 * @param string $route  Route path.
+		 */
+		public function __construct( string $method = 'GET', string $route = '' ) {
+			unset( $route );
+			$this->method = $method;
+		}
+
+		/**
+		 * @param string $key Parameter key.
+		 * @return mixed
+		 */
+		public function get_param( string $key ) {
+			return $this->params[ $key ] ?? null;
+		}
+
+		/**
+		 * @param string $key   Parameter key.
+		 * @param mixed  $value Parameter value.
+		 */
+		public function set_param( string $key, $value ): void {
+			$this->params[ $key ] = $value;
+		}
+
+		/**
+		 * @param array<string, mixed> $params Query parameters.
+		 */
+		public function set_query_params( array $params ): void {
+			$this->query_params = $params;
+			foreach ( $params as $key => $value ) {
+				$this->params[ (string) $key ] = $value;
+			}
+		}
+
+		/**
+		 * @return array<string, mixed>
+		 */
+		public function get_query_params(): array {
+			return $this->query_params;
+		}
+
+		/**
+		 * @return string
+		 */
+		public function get_method(): string {
+			return $this->method;
+		}
+
+		/**
+		 * @param string $method HTTP method.
+		 */
+		public function set_method( string $method ): void {
+			$this->method = $method;
+		}
+
+		/**
+		 * @param array<string, mixed>|null $params JSON body parameters.
+		 */
+		public function set_json_params( ?array $params ): void {
+			$this->json_params = $params;
+		}
+
+		/**
+		 * @return array<string, mixed>|null
+		 */
+		public function get_json_params(): ?array {
+			return $this->json_params;
+		}
+	}
+}
+
+if ( ! class_exists( 'WP_REST_Response', false ) ) {
+	/**
+	 * Minimal REST response stub for PHPUnit.
+	 */
+	class WP_REST_Response {
+		/**
+		 * @var mixed
+		 */
+		private $data;
+
+		/**
+		 * @var int
+		 */
+		private $status;
+
+		/**
+		 * @var array<string, string>
+		 */
+		private $headers = array();
+
+		/**
+		 * @param mixed $data   Response body.
+		 * @param int   $status HTTP status.
+		 */
+		public function __construct( $data = null, int $status = 200 ) {
+			$this->data   = $data;
+			$this->status = $status;
+		}
+
+		/**
+		 * @return mixed
+		 */
+		public function get_data() {
+			return $this->data;
+		}
+
+		/**
+		 * @return int
+		 */
+		public function get_status(): int {
+			return $this->status;
+		}
+
+		/**
+		 * @param string $key   Header name.
+		 * @param string $value Header value.
+		 */
+		public function header( string $key, string $value ): void {
+			$this->headers[ $key ] = $value;
+		}
+
+		/**
+		 * @param string $key Header name.
+		 * @return string|null
+		 */
+		public function get_header( string $key ): ?string {
+			return $this->headers[ $key ] ?? null;
+		}
+	}
+}
+
+if ( ! class_exists( 'WP_Error', false ) ) {
+	/**
+	 * Minimal error stub for PHPUnit.
+	 */
+	class WP_Error {
+		/**
+		 * @var string
+		 */
+		private $code;
+
+		/**
+		 * @var string
+		 */
+		private $message;
+
+		/**
+		 * @var array<string, mixed>
+		 */
+		private $data;
+
+		/**
+		 * @param string               $code    Error code.
+		 * @param string               $message Error message.
+		 * @param array<string, mixed> $data    Optional data.
+		 */
+		public function __construct( string $code = '', string $message = '', array $data = array() ) {
+			$this->code    = $code;
+			$this->message = $message;
+			$this->data    = $data;
+		}
+
+		/**
+		 * @return string
+		 */
+		public function get_error_code(): string {
+			return $this->code;
+		}
+
+		/**
+		 * @return string
+		 */
+		public function get_error_message(): string {
+			return $this->message;
+		}
+
+		/**
+		 * @param string|null $code Optional error code.
+		 * @return mixed
+		 */
+		public function get_error_data( ?string $code = null ) {
+			unset( $code );
+			return $this->data;
+		}
+	}
+}
+
+if ( ! function_exists( 'wp_remote_retrieve_response_code' ) ) {
+	/**
+	 * @param array<string, mixed> $response HTTP response array.
+	 * @return int
+	 */
+	function wp_remote_retrieve_response_code( array $response ): int {
+		if ( isset( $response['response']['code'] ) ) {
+			return (int) $response['response']['code'];
+		}
+
+		return (int) ( $response['http_response_code'] ?? 200 );
+	}
+}
+
+if ( ! function_exists( 'wp_remote_retrieve_body' ) ) {
+	/**
+	 * @param array<string, mixed> $response HTTP response array.
+	 * @return string
+	 */
+	function wp_remote_retrieve_body( array $response ): string {
+		$body = $response['body'] ?? '';
+
+		return is_string( $body ) ? $body : wp_json_encode( $body );
+	}
+}
+
+if ( ! function_exists( 'get_plugin_data' ) ) {
+	/**
+	 * @param string $plugin_file Plugin file path.
+	 * @return array<string, string>
+	 */
+	function get_plugin_data( string $plugin_file ): array {
+		unset( $plugin_file );
+		return array(
+			'Name'    => 'Freemius for WordPress',
+			'Version' => '0.4.2',
+		);
+	}
+}
+
+if ( ! function_exists( 'add_query_arg' ) ) {
+	/**
+	 * @param array<string, mixed>|string $args   Query args or key.
+	 * @param string                      $url    URL.
+	 * @param string|null                 $unused Optional legacy arg.
+	 * @return string
+	 */
+	function add_query_arg( $args, string $url = '', ?string $unused = null ): string {
+		unset( $unused );
+
+		if ( is_string( $args ) ) {
+			$key   = $args;
+			$value = func_num_args() > 2 ? func_get_arg( 2 ) : '';
+			$url   = func_num_args() > 1 ? (string) func_get_arg( 1 ) : '';
+			$args  = array( $key => $value );
+		}
+
+		if ( ! is_array( $args ) || array() === $args ) {
+			return $url;
+		}
+
+		$separator = str_contains( $url, '?' ) ? '&' : '?';
+
+		return $url . $separator . http_build_query( $args );
+	}
+}


### PR DESCRIPTION

Introduces PHPUnit 9.6 with Brain Monkey for WordPress function mocking, covering Settings sanitization/schemas, Api proxy/cache/auth flows, Scope/Button block rendering, and Blocks registration.

Adds tests/php bootstrap with WP stubs and build fixtures, composer test:php script, phpcs exclude for tests/, and a unit-tests GitHub Actions workflow on PR/push to develop and main.

Site owners see no behavior change; this establishes automated regression coverage for the plugin's PHP layer before future features ship.