### PR TITLE
feat: add WordPress Playground PR preview

### DIFF
--- a/.github/workflows/pr-preview-build.yml
+++ b/.github/workflows/pr-preview-build.yml
@@ -1,0 +1,22 @@
+---
+# Builds freemius.zip from the PR branch. After this workflow is merged to
+# develop, subsequent PRs get a Playground Preview button once publish runs.
+name: PR Preview - Build
+
+on:
+    pull_request:
+        types: [opened, synchronize, reopened, edited]
+
+jobs:
+    build:
+        uses: WordPress/action-wp-playground-pr-preview/.github/workflows/preview-build.yml@v3
+        with:
+            artifacts: freemius=freemius.zip
+            node-version: '24'
+            php-version: '8.2'
+            build-command: |
+                set -euo pipefail
+                npm ci
+                composer install --no-dev --optimize-autoloader --no-interaction
+                npm run build
+                npm run plugin-zip

--- a/.github/workflows/pr-preview-publish.yml
+++ b/.github/workflows/pr-preview-publish.yml
@@ -1,0 +1,67 @@
+---
+# Publishes the built ZIP to ci-artifacts and posts the Preview button on the PR.
+# Both preview workflows must exist on develop before previews work on other PRs.
+name: PR Preview - Publish
+
+on:
+    workflow_run:
+        workflows: ['PR Preview - Build']
+        types: [completed]
+
+permissions:
+    contents: write
+    pull-requests: write
+
+jobs:
+    publish:
+        permissions:
+            contents: write
+            pull-requests: write
+        uses: WordPress/action-wp-playground-pr-preview/.github/workflows/preview-publish.yml@v3
+        with:
+            blueprint: |
+                {
+                  "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+                  "landingPage": "/wp-admin/post.php?post=4&action=edit",
+                  "preferredVersions": {
+                    "php": "8.3",
+                    "wp": "latest"
+                  },
+                  "features": {
+                    "networking": true
+                  },
+                  "login": true,
+                  "siteOptions": {
+                    "blogname": "Freemius for WordPress"
+                  },
+                  "steps": [
+                    {
+                      "step": "installPlugin",
+                      "pluginZipFile": {
+                        "resource": "url",
+                        "url": "{{ARTIFACT_URL:freemius}}"
+                      },
+                      "options": {
+                        "activate": true
+                      }
+                    },
+                    {
+                      "step": "installTheme",
+                      "themeData": {
+                        "resource": "wordpress.org/themes",
+                        "slug": "ollie"
+                      }
+                    },
+                    {
+                      "step": "importWxr",
+                      "file": {
+                        "resource": "url",
+                        "url": "https://raw.githubusercontent.com/Freemius/freemius-wp-plugin/refs/heads/develop/.wordpress-org/blueprints/content.xml"
+                      }
+                    },
+                    {
+                      "step": "runPHP",
+                      "code": "<?php require '/wordpress/wp-load.php'; update_option( 'freemius_products', array( array( 'product_id' => 19794, 'token' => '1234567890' ) ) );"
+                    }
+                  ]
+                }


### PR DESCRIPTION
Adds GitHub Actions workflows so pull requests get a Playground Preview button with the built plugin from the PR branch.

Introduces `pr-preview-build.yml` and `pr-preview-publish.yml` using `WordPress/action-wp-playground-pr-preview@v3`. The build job runs `npm ci`, `composer install --no-dev`, `npm run build`, and `npm run plugin-zip` to produce `freemius.zip`. The publish job uploads the ZIP to the `ci-artifacts` prerelease and posts a preview button using a blueprint adapted from `.wordpress-org/blueprints/blueprint.json` (Ollie theme, demo content, sample product config) with `{{ARTIFACT_URL:freemius}}` for the PR-built plugin.

Reviewers can test block editor demos and admin UI on every PR without a local WordPress install. Requires merging to `develop` before previews activate on subsequent PRs.